### PR TITLE
Fixed memory leak. Added in exit_and_cleanup() in cycle().

### DIFF
--- a/src/drivers/heater/heater.h
+++ b/src/drivers/heater/heater.h
@@ -240,7 +240,7 @@ private:
 	struct sensor_accel_s _sensor_accel;
 
 	/** @param _sensor_accel_sub The accelerometer subtopic subscribed to.*/
-	int _sensor_accel_subscription;
+	int _sensor_accel_sub;
 
 	/** @param _sensor_temperature The sensor's reported temperature. */
 	float _sensor_temperature;


### PR DESCRIPTION
Fixed a memory caused by not unsubscribing from uORB.
![selection_001](https://user-images.githubusercontent.com/37091262/44930403-68df7f80-ad1b-11e8-98c5-5d3f49e8429a.png)

Added in `exit_and_cleanup()` in the check for `should_exit()`.

Also changed a variable name to match the other variable `_params_sub`.